### PR TITLE
Fix CI workflow to trigger on master branch instead of main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
The repository uses master as its default branch, but the CI workflow
was configured to trigger on main.

https://claude.ai/code/session_012YUdc8wsrMw8E4cbTgHrgw